### PR TITLE
added scrollThumbs option

### DIFF
--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -19,7 +19,8 @@ type Props = {
   images: {uri: string}[],
   renderHeader: ({[key: string]: any}, number) => void,
   renderFooter: ({[key: string]: any}, number) => void,
-  scrollThumbs: boolean
+  scrollThumbs: boolean,
+  showModal: boolean
 }
 
 export default class ImageCarousel extends Component {
@@ -86,7 +87,7 @@ export default class ImageCarousel extends Component {
       <View>
         <Modal
           onRequestClose={this._closeModal}
-          visible={ (showModal || this.props.showModal) }
+          visible={ ( (showModal || this.props.showModal) ? true : false ) }
           transparent={true}>
           <ImageViewer
             renderHeader={() => <Header onClose={() => this._closeModal()}/>}

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -86,7 +86,7 @@ export default class ImageCarousel extends Component {
       <View>
         <Modal
           onRequestClose={this._closeModal}
-          visible={showModal}
+          visible={ (showModal || this.props.showModal) }
           transparent={true}>
           <ImageViewer
             renderHeader={() => <Header onClose={() => this._closeModal()}/>}

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -6,10 +6,12 @@ import React, {Component} from 'react';
 import {
   View,
   Modal,
+  TouchableHighlight,
 } from 'react-native';
 import ImageViewer from 'react-native-image-zoom-viewer';
 import Header from './viewer-header';
 import Carousel from './carousel';
+import ImageWithLoading from './image';
 
 type Props = {
   indicatorAtBottom: boolean,
@@ -17,6 +19,7 @@ type Props = {
   images: {uri: string}[],
   renderHeader: ({[key: string]: any}, number) => void,
   renderFooter: ({[key: string]: any}, number) => void,
+  scrollThumbs: boolean
 }
 
 export default class ImageCarousel extends Component {
@@ -25,6 +28,7 @@ export default class ImageCarousel extends Component {
     showModal: boolean,
     imageIndex: number,
     fromCarousel: boolean,
+    scrollThumbs: boolean,
   }
 
   static defaultProps = {
@@ -67,7 +71,7 @@ export default class ImageCarousel extends Component {
 
   render() {
     const {images, renderHeader, renderFooter,
-      indicatorAtBottom, indicatorOffset, ...rest} = this.props;
+      indicatorAtBottom, indicatorOffset, scrollThumbs, ...rest} = this.props;
     const {showModal, imageIndex, fromCarousel} = this.state;
     let extraPadding = {};
 
@@ -99,16 +103,26 @@ export default class ImageCarousel extends Component {
         </Modal>
         {renderHeader(images[imageIndex], imageIndex)}
         <View style={extraPadding}>
-          <Carousel
-            {...rest}
-            indicatorOffset={indicatorOffset}
-            indicatorAtBottom={indicatorAtBottom}
-            images={images}
-            initialPage={imageIndex}
-            fromCarousel={fromCarousel}
-            onPressImage={this._onPressImg}
-            onPageChange={this._updateIndex}
-            />
+          {(scrollThumbs ?
+              <Carousel
+                {...rest}
+                indicatorOffset={indicatorOffset}
+                indicatorAtBottom={indicatorAtBottom}
+                images={images}
+                initialPage={imageIndex}
+                fromCarousel={fromCarousel}
+                onPressImage={this._onPressImg}
+                onPageChange={this._updateIndex}
+                />
+            :
+              <TouchableHighlight style={{flex:1}} onPress={() => this._onPressImg(0)}>
+                <ImageWithLoading style={{
+                  flex: 1,
+                  width: 10000,
+                  height: 10000,
+                }} resizeMode="center" source={{uri: images[0].uri }} />
+              </TouchableHighlight>
+          )}
         </View>
         {renderFooter(images[imageIndex], imageIndex)}
       </View>

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -83,11 +83,15 @@ export default class ImageCarousel extends Component {
       extraPadding = {paddingTop: -indicatorOffset};
     }
 
+if(this.props.showModal) {
+  this.setState({showModal:true});
+}
+
     return (
       <View>
         <Modal
           onRequestClose={this._closeModal}
-          visible={ ( (showModal || this.props.showModal) ? true : false ) }
+          visible={showModal}
           transparent={true}>
           <ImageViewer
             renderHeader={() => <Header onClose={() => this._closeModal()}/>}

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -71,7 +71,7 @@ export default class ImageCarousel extends Component {
 
   render() {
     const {images, renderHeader, renderFooter,
-      indicatorAtBottom, indicatorOffset, scrollThumbs, ...rest} = this.props;
+      indicatorAtBottom, indicatorOffset, scrollThumbs, width, height, ...rest} = this.props;
     const {showModal, imageIndex, fromCarousel} = this.state;
     let extraPadding = {};
 
@@ -118,8 +118,8 @@ export default class ImageCarousel extends Component {
               <TouchableHighlight style={{flex:1}} onPress={() => this._onPressImg(0)}>
                 <ImageWithLoading style={{
                   flex: 1,
-                  width: 10000,
-                  height: 10000,
+                  width: width,
+                  height: height,
                 }} resizeMode="center" source={{uri: images[0].uri }} />
               </TouchableHighlight>
           )}

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -40,7 +40,7 @@ export default class ImageCarousel extends Component {
   constructor(props: Props) {
     super(props);
     this.state = {
-      showModal: false,
+      showModal: (this.props.showModal ? true: false),
       imageIndex: 0,
       fromCarousel: false,
     };
@@ -82,10 +82,6 @@ export default class ImageCarousel extends Component {
     } else if (!indicatorAtBottom && indicatorOffset < 0) {
       extraPadding = {paddingTop: -indicatorOffset};
     }
-
-if(this.props.showModal) {
-  this.setState({showModal:true});
-}
 
     return (
       <View>

--- a/src/image.js
+++ b/src/image.js
@@ -9,7 +9,8 @@ import type {ImageProps} from './types';
 export default class ImageWithLoading extends Component {
   props: ImageProps
   state: {
-    loading: boolean
+    loading: boolean,
+    resizeMode: string
   }
 
   constructor(props: ImageProps) {
@@ -32,7 +33,7 @@ export default class ImageWithLoading extends Component {
   }
 
   render() {
-    const {style, source} = this.props;
+    const {style, source, resizeMode} = this.props;
     const {loading} = this.state;
     return (
       <View style={style}>
@@ -53,7 +54,7 @@ export default class ImageWithLoading extends Component {
           source={source}
           onLoadStart={this._onLoadStart}
           onLoadEnd={this._onLoadEnd}
-          resizeMode="contain"
+          resizeMode={resizeMode ? resizeMode : "contain"}
           />
       </View>
     );


### PR DESCRIPTION
Added “Scroll with Thumbnails” functionality

Added scrollThumbs prop that, when set to false, will statically show the first image in the carousel as a thumbnail, rather than a scrolling carousel of thumbnails. When the scrollThumbs prop is set to true, the carousel will retain its default scrolling thumbnail functionality.

This functionality is good for an "album cover" style feature