### PR TITLE
Additional Carousel Functionality Added

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-page",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "react-native image carousel",
   "main": "./src/image-carousel.js",
   "directories": {
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "react-native-carousel-view": "^0.5.1",
-    "react-native-image-zoom-viewer": "^2.2.3"
+    "react-native-image-zoom-viewer": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "react-native-carousel-view": "^0.5.1",
-    "react-native-image-zoom-viewer": "github:bradsolves/react-native-image-viewer"
+    "react-native-image-zoom-viewer": "^2.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "react-native-carousel-view": "^0.5.1",
-    "react-native-image-zoom-viewer": "^2.0.6"
+    "react-native-image-zoom-viewer": "github:bradsolves/react-native-image-viewer"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
   "dependencies": {
     "react-native-carousel-view": "^0.5.1",
     "react-native-image-zoom-viewer": "^3.0.0"
-  }
+  },
+  "repository": "https://github.com/bradsolves/react-native-image-page.git"
 }

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -3,7 +3,7 @@
  */
 
 import React, {Component} from 'react';
-import Carousel from 'react-native-carousel-view';
+import CarouselView from 'react-native-carousel-view';
 import TouchableImage from './touchable-image';
 
 type Props = {
@@ -13,7 +13,7 @@ type Props = {
   onPageChange: (number, boolean) => void,
 }
 
-export default class Carosuel extends Component {
+export default class Carousel extends Component {
   props: Props
   scrolling: boolean
 
@@ -47,7 +47,7 @@ export default class Carosuel extends Component {
   render() {
     const {onPressImage, images, ...rest} = this.props;
     return (
-      <Carousel
+      <CarouselView
         {...rest}
         onPageChange={this._setPageChange}
         onScroll={this._onScroll}
@@ -65,7 +65,7 @@ export default class Carosuel extends Component {
             );
           })
         }
-      </Carousel>
+      </CarouselView>
     );
   }
 }

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -19,7 +19,8 @@ type Props = {
   images: {uri: string}[],
   renderHeader: ({[key: string]: any}, number) => void,
   renderFooter: ({[key: string]: any}, number) => void,
-  scrollThumbs: boolean
+  scrollThumbs: boolean,
+  showModal: boolean
 }
 
 export default class ImageCarousel extends Component {
@@ -86,7 +87,7 @@ export default class ImageCarousel extends Component {
       <View>
         <Modal
           onRequestClose={this._closeModal}
-          visible={ (showModal || this.props.showModal) }
+          visible={ ( (showModal || this.props.showModal) ? true : false ) }
           transparent={true}>
           <ImageViewer
             renderHeader={() => <Header onClose={() => this._closeModal()}/>}

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -56,7 +56,7 @@ export default class ImageCarousel extends Component {
     (this: any)._closeModal = this._closeModal.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(nextProps) {
     if (nextProps.showModal !== this.state.showModal) {
       this.setState({ showModal: nextProps.showModal });
     }

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -102,6 +102,23 @@ export default class ImageCarousel extends Component {
           transparent={true}>
           <ImageViewer
             renderHeader={() => <Header onClose={() => this._closeModal()}/>}
+            loadingRender={() =>
+                      <View
+                          style={{
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                          }}
+                        >
+                        <ActivityIndicator
+                          style={{
+                            flex: 1,
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                          }}
+                          animating={true}
+                          />
+                      </View>
+                    }
             onChange={this._updateIndex}
             saveToLocalByLongPress={false}
             imageUrls={images.map((img) => {
@@ -128,11 +145,15 @@ export default class ImageCarousel extends Component {
                 />
             :
               <TouchableHighlight style={{flex:1}} onPress={() => this._onPressImg(imageIndex)}>
-                <ImageWithLoading style={{
-                  flex: 1,
-                  width: width,
-                  height: height,
-                }} resizeMode="center" source={{uri: images[0].uri }} />
+                <ImageWithLoading
+                  style={{
+                    flex: 1,
+                    width: width,
+                    height: height,
+                  }}
+                  resizeMode="center"
+                  source={{uri: images[0].uri }}
+                  />
               </TouchableHighlight>
           )}
         </View>

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -86,7 +86,7 @@ export default class ImageCarousel extends Component {
       <View>
         <Modal
           onRequestClose={this._closeModal}
-          visible={showModal}
+          visible={ (showModal || this.props.showModal) }
           transparent={true}>
           <ImageViewer
             renderHeader={() => <Header onClose={() => this._closeModal()}/>}

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -6,10 +6,12 @@ import React, {Component} from 'react';
 import {
   View,
   Modal,
+  TouchableHighlight,
 } from 'react-native';
 import ImageViewer from 'react-native-image-zoom-viewer';
 import Header from './viewer-header';
 import Carousel from './carousel';
+import ImageWithLoading from './image';
 
 type Props = {
   indicatorAtBottom: boolean,
@@ -17,6 +19,7 @@ type Props = {
   images: {uri: string}[],
   renderHeader: ({[key: string]: any}, number) => void,
   renderFooter: ({[key: string]: any}, number) => void,
+  scrollThumbs: boolean
 }
 
 export default class ImageCarousel extends Component {
@@ -25,6 +28,7 @@ export default class ImageCarousel extends Component {
     showModal: boolean,
     imageIndex: number,
     fromCarousel: boolean,
+    scrollThumbs: boolean,
   }
 
   static defaultProps = {
@@ -67,7 +71,7 @@ export default class ImageCarousel extends Component {
 
   render() {
     const {images, renderHeader, renderFooter,
-      indicatorAtBottom, indicatorOffset, ...rest} = this.props;
+      indicatorAtBottom, indicatorOffset, scrollThumbs, ...rest} = this.props;
     const {showModal, imageIndex, fromCarousel} = this.state;
     let extraPadding = {};
 
@@ -99,16 +103,26 @@ export default class ImageCarousel extends Component {
         </Modal>
         {renderHeader(images[imageIndex], imageIndex)}
         <View style={extraPadding}>
-          <Carousel
-            {...rest}
-            indicatorOffset={indicatorOffset}
-            indicatorAtBottom={indicatorAtBottom}
-            images={images}
-            initialPage={imageIndex}
-            fromCarousel={fromCarousel}
-            onPressImage={this._onPressImg}
-            onPageChange={this._updateIndex}
-            />
+          {(scrollThumbs ?
+              <Carousel
+                {...rest}
+                indicatorOffset={indicatorOffset}
+                indicatorAtBottom={indicatorAtBottom}
+                images={images}
+                initialPage={imageIndex}
+                fromCarousel={fromCarousel}
+                onPressImage={this._onPressImg}
+                onPageChange={this._updateIndex}
+                />
+            :
+              <TouchableHighlight style={{flex:1}} onPress={() => this._onPressImg(0)}>
+                <ImageWithLoading style={{
+                  flex: 1,
+                  width: 10000,
+                  height: 10000,
+                }} resizeMode="center" source={{uri: images[0].uri }} />
+              </TouchableHighlight>
+          )}
         </View>
         {renderFooter(images[imageIndex], imageIndex)}
       </View>

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -83,11 +83,15 @@ export default class ImageCarousel extends Component {
       extraPadding = {paddingTop: -indicatorOffset};
     }
 
+if(this.props.showModal) {
+  this.setState({showModal:true});
+}
+
     return (
       <View>
         <Modal
           onRequestClose={this._closeModal}
-          visible={ ( (showModal || this.props.showModal) ? true : false ) }
+          visible={showModal}
           transparent={true}>
           <ImageViewer
             renderHeader={() => <Header onClose={() => this._closeModal()}/>}

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -7,6 +7,7 @@ import {
   View,
   Modal,
   TouchableHighlight,
+  ActivityIndicator,
 } from 'react-native';
 import ImageViewer from 'react-native-image-zoom-viewer';
 import Header from './viewer-header';

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -52,8 +52,10 @@ export default class ImageCarousel extends Component {
     (this: any)._closeModal = this._closeModal.bind(this);
   }
 
-componentDidMount() {
+componentWillMount() {
+console.log("will mount")
   if(this.props.showModal) {
+console.log("set to true")
     this.setState({showModal:true})
   }
 }

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -35,12 +35,14 @@ export default class ImageCarousel extends Component {
   static defaultProps = {
     renderHeader: () => {},
     renderFooter: () => {},
+    scrollThumbs: true,
+    showModal: false,
   }
 
   constructor(props: Props) {
     super(props);
     this.state = {
-      showModal: (this.props.showModal ? true: false),
+      showModal: false,
       imageIndex: 0,
       fromCarousel: false,
     };
@@ -50,6 +52,11 @@ export default class ImageCarousel extends Component {
     (this: any)._closeModal = this._closeModal.bind(this);
   }
 
+componentDidMount() {
+  if(this.props.showModal) {
+    this.setState({showModal:true})
+  }
+}
   _onPressImg(i) {
     this.setState({
       showModal: true,

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -23,6 +23,7 @@ type Props = {
   scrollThumbs: boolean,
   showModal: boolean,
   handleModal: func,
+  supportedOrientations: array,
 }
 
 export default class ImageCarousel extends Component {
@@ -39,6 +40,7 @@ export default class ImageCarousel extends Component {
     renderFooter: () => {},
     scrollThumbs: true,
     showModal: false,
+    supportedOrientations: ['portrait', 'portrait-upside-down', 'landscape', 'landscape-left', 'landscape-right'],
   }
 
   constructor(props: Props) {
@@ -84,7 +86,7 @@ export default class ImageCarousel extends Component {
 
   render() {
     const {images, renderHeader, renderFooter,
-      indicatorAtBottom, indicatorOffset, scrollThumbs, width, height, ...rest} = this.props;
+      indicatorAtBottom, indicatorOffset, scrollThumbs, supportedOrientations, width, height, ...rest} = this.props;
     const {showModal, imageIndex, fromCarousel} = this.state;
     let extraPadding = {};
 
@@ -100,6 +102,7 @@ export default class ImageCarousel extends Component {
         <Modal
           onRequestClose={this._closeModal}
           visible={showModal}
+          supportedOrientations={supportedOrientations}
           transparent={true}>
           <ImageViewer
             renderHeader={() => <Header onClose={() => this._closeModal()}/>}

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -71,7 +71,7 @@ export default class ImageCarousel extends Component {
 
   render() {
     const {images, renderHeader, renderFooter,
-      indicatorAtBottom, indicatorOffset, scrollThumbs, ...rest} = this.props;
+      indicatorAtBottom, indicatorOffset, scrollThumbs, width, height, ...rest} = this.props;
     const {showModal, imageIndex, fromCarousel} = this.state;
     let extraPadding = {};
 
@@ -118,8 +118,8 @@ export default class ImageCarousel extends Component {
               <TouchableHighlight style={{flex:1}} onPress={() => this._onPressImg(0)}>
                 <ImageWithLoading style={{
                   flex: 1,
-                  width: 10000,
-                  height: 10000,
+                  width: width,
+                  height: height,
                 }} resizeMode="center" source={{uri: images[0].uri }} />
               </TouchableHighlight>
           )}

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -40,7 +40,7 @@ export default class ImageCarousel extends Component {
   constructor(props: Props) {
     super(props);
     this.state = {
-      showModal: false,
+      showModal: (this.props.showModal ? true: false),
       imageIndex: 0,
       fromCarousel: false,
     };
@@ -82,10 +82,6 @@ export default class ImageCarousel extends Component {
     } else if (!indicatorAtBottom && indicatorOffset < 0) {
       extraPadding = {paddingTop: -indicatorOffset};
     }
-
-if(this.props.showModal) {
-  this.setState({showModal:true});
-}
 
     return (
       <View>

--- a/src/image-carousel.js
+++ b/src/image-carousel.js
@@ -20,7 +20,8 @@ type Props = {
   renderHeader: ({[key: string]: any}, number) => void,
   renderFooter: ({[key: string]: any}, number) => void,
   scrollThumbs: boolean,
-  showModal: boolean
+  showModal: boolean,
+  handleModal: func,
 }
 
 export default class ImageCarousel extends Component {
@@ -42,7 +43,7 @@ export default class ImageCarousel extends Component {
   constructor(props: Props) {
     super(props);
     this.state = {
-      showModal: false,
+      showModal: this.props.showModal,
       imageIndex: 0,
       fromCarousel: false,
     };
@@ -52,18 +53,18 @@ export default class ImageCarousel extends Component {
     (this: any)._closeModal = this._closeModal.bind(this);
   }
 
-componentWillMount() {
-console.log("will mount")
-  if(this.props.showModal) {
-console.log("set to true")
-    this.setState({showModal:true})
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.showModal !== this.state.showModal) {
+      this.setState({ showModal: nextProps.showModal });
+    }
   }
-}
+
   _onPressImg(i) {
     this.setState({
       showModal: true,
       imageIndex: i,
     });
+    this.props.handleModal();
   }
 
   _updateIndex(i, fromCarousel) {
@@ -77,6 +78,7 @@ console.log("set to true")
     this.setState({
       showModal: false,
     });
+    this.props.handleModal();
   }
 
   render() {
@@ -125,7 +127,7 @@ console.log("set to true")
                 onPageChange={this._updateIndex}
                 />
             :
-              <TouchableHighlight style={{flex:1}} onPress={() => this._onPressImg(0)}>
+              <TouchableHighlight style={{flex:1}} onPress={() => this._onPressImg(imageIndex)}>
                 <ImageWithLoading style={{
                   flex: 1,
                   width: width,

--- a/src/image.js
+++ b/src/image.js
@@ -9,7 +9,8 @@ import type {ImageProps} from './types';
 export default class ImageWithLoading extends Component {
   props: ImageProps
   state: {
-    loading: boolean
+    loading: boolean,
+    resizeMode: string
   }
 
   constructor(props: ImageProps) {
@@ -32,7 +33,7 @@ export default class ImageWithLoading extends Component {
   }
 
   render() {
-    const {style, source} = this.props;
+    const {style, source, resizeMode} = this.props;
     const {loading} = this.state;
     return (
       <View style={style}>
@@ -53,7 +54,7 @@ export default class ImageWithLoading extends Component {
           source={source}
           onLoadStart={this._onLoadStart}
           onLoadEnd={this._onLoadEnd}
-          resizeMode="contain"
+          resizeMode={resizeMode ? resizeMode : "contain"}
           />
       </View>
     );


### PR DESCRIPTION
**Added ActivityIndicator to Carousel**
This shows a visual indicator when images are loading in full screen carousel mode.

**Added “Scroll with Thumbnails” functionality**
Added scrollThumbs prop that, when set to false, will statically show the first image in the carousel as a thumbnail, rather than a scrolling carousel of thumbnails. When the scrollThumbs prop is set to true, the carousel will retain its default scrolling thumbnail functionality.
This functionality is good for an "album cover" style feature

**Added "Show Modal" functionality**
Added showModal prop that, when set to true, will launch the carousel modal. 
This is especially useful if you are trying to show the carousel model by clicking something other than the carousel thumbnail.